### PR TITLE
Clearer bus route reading

### DIFF
--- a/alexa.js
+++ b/alexa.js
@@ -102,10 +102,10 @@ function getWelcomeResponse(callback) {
     var sessionAttributes = {};
     var cardTitle = "Welcome";
     var speechOutput = "Welcome to the Chicago Bus Stop skill. " +
-        "Please tell me which bus stop you would like the schedule for.  For example, ask me,  when is the next bus at stop 3773";
+        "Please tell me which bus stop you would like the schedule for.";
     // If the user either does not reply to the welcome message or says something that is not
     // understood, they will be prompted again with this text.
-    var repromptText = "Which stop would you like to know the schedule for";
+    var repromptText = "For example, ask me,  when is the next bus at stop three seven seven three";
     var shouldEndSession = false;
 
     callback(sessionAttributes,
@@ -117,7 +117,7 @@ function getHelp(callback) {
     var sessionAttributes = {};
     var cardTitle = "Help";
     var speechOutput = "To get the schedule for a bus stop either ask for the next buses at that specific stop number, or, give the direction, route number, and cross streets," +
-        "For example, when are the next buses at stop number 3766, or, when is the next north bound twenty two bus at Clark and Addison.";
+        "For example, when are the next buses at stop number three seven six six, or, when is the next north bound twenty two bus at Clark and Addison.";
     // If the user either does not reply to the welcome message or says something that is not
     // understood, they will be prompted again with this text.
     var repromptText = "Which stop would you like to know the schedule for";

--- a/package.json
+++ b/package.json
@@ -20,10 +20,8 @@
   "author": "Scot Goodhart",
   "license": "ISC",
   "dependencies": {
-    "cta-bus-tracker": "0.0.2",
-    "lodash": "^4.11.2",
-    "moment": "^2.13.0",
-    "moment-timezone": "^0.5.3"
+    "cta-bus-tracker": "https://github.com/BoldBigflank/Node-CTA-Bus-Tracker.git",
+    "lodash": "^4.11.2"
   },
   "devDependencies": {
     "dotenv": "^2.0.0"

--- a/tools.js
+++ b/tools.js
@@ -8,7 +8,6 @@ BUS_STOP_NAME - every bus stop for every route ie both directions
 require('dotenv').config();
 var cta = require('cta-bus-tracker');
 var busTracker = cta(process.env.API_KEY);
-var moment = require('moment-timezone');
 var _ = require('lodash');
 var fs = require('fs');
 var _TOOLS = 'tool_output/';


### PR DESCRIPTION
combines the same routes, but states each unique route

Also, the arrival time is in v2 of the cta bus api, which the node package hasn't switched to yet, so I forked that and updated the package.json. Moment package isn't required any more.

And a minor change to the welcome message so experienced users don't need to wait through the example every time.